### PR TITLE
add configuration from file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,225 @@
+package config
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/apex/log"
+	"github.com/mitchellh/go-homedir"
+
+	"github.com/plan-systems/plan-vault-libp2p/p2p"
+	pb "github.com/plan-systems/plan-vault-libp2p/protos"
+	"github.com/plan-systems/plan-vault-libp2p/server"
+	"github.com/plan-systems/plan-vault-libp2p/store"
+)
+
+const defaultEtcDir = "/etc/plan-vault"
+const defaultDataDir = "/var/run/plan-vault"
+
+var (
+	flagConfigPath  string
+	flagLogLevel    string
+	flagDataDir     string
+	flagKeyringDir  string
+	flagPrintConfig bool
+)
+
+func init() {
+	flag.StringVar(&flagConfigPath, "config", "", "configuration file")
+	flag.StringVar(&flagLogLevel, "log_level", "debug", "log level")
+	flag.StringVar(&flagDataDir, "data_dir", defaultDataDir,
+		"directory for database")
+	flag.StringVar(&flagKeyringDir, "keyring_dir", defaultEtcDir,
+		"directory for keyring storage")
+	flag.BoolVar(&flagPrintConfig, "print", false,
+		"print the resulting configuration file and exit")
+	flag.Parse()
+}
+
+type configSource struct {
+	KeyDir  string         `json:"key_dir"`
+	Store   *storeConfig   `json:"store"`
+	Server  *grpcConfig    `json:"server"`
+	P2P     *p2pConfig     `json:"p2p"`
+	Logging *loggingConfig `json:"logging"`
+}
+
+type storeConfig struct {
+	DataDir string `json:"data_dir"`
+}
+
+type grpcConfig struct {
+	BindAddr string `json:"addr"`
+	Port     int    `json:"port"`
+	TLSCert  string `json:"tls_cert_file"`
+	TLSKey   string `json:"tls_key_file"`
+}
+
+type p2pConfig struct {
+	MDNS     bool   `json:"mdns"`
+	URI      string `json:"channel"`
+	TCPAddr  string `json:"tcp_addr"`
+	TCPPort  int    `json:"tcp_port"`
+	QUICAddr string `json:"quic_addr"`
+	QUICPort int    `json:"quic_port"`
+}
+
+// TODO: add formatting options here
+type loggingConfig struct {
+	Level string `json:"level"`
+}
+
+func newConfigSource() *configSource {
+	cfg := defaultConfigSrc()
+	path := configFilePath()
+	if path != "" {
+		cfgData, err := ioutil.ReadFile(path)
+		if err != nil && !os.IsNotExist(err) {
+			log.Fatalf("could not read config file: %v", err)
+		}
+
+		err = json.Unmarshal(cfgData, cfg)
+		if err != nil {
+			log.Fatalf("could not decode configuration file:", err)
+		}
+	}
+
+	// TODO: in the future we might turn this into a subcommand if
+	// we end up having other control subcommands built into the vault
+	if flagPrintConfig {
+		cfg.Print()
+		os.Exit(0)
+	}
+
+	return cfg
+}
+
+func defaultConfigSrc() *configSource {
+
+	flagKeyringDir, err := homedir.Expand(flagKeyringDir)
+	if err != nil {
+		log.Fatalf("could not parse keyring_dir path: %v", err)
+	}
+	flagDataDir, err := homedir.Expand(flagDataDir)
+	if err != nil {
+		log.Fatalf("could not parse data_dir path: %v", err)
+	}
+
+	src := &configSource{
+		KeyDir: flagKeyringDir,
+		Store: &storeConfig{
+			DataDir: flagDataDir,
+		},
+		Server: &grpcConfig{
+			BindAddr: "127.0.0.1",
+			Port:     int(pb.Const_DefaultGrpcServicePort),
+			TLSCert:  filepath.Join(flagKeyringDir, "vault_cert.pem"),
+			TLSKey:   filepath.Join(flagKeyringDir, "vault_key.pem"),
+		},
+		P2P: &p2pConfig{
+			MDNS:     true,
+			URI:      "/DISCOVERY",
+			TCPAddr:  "127.0.0.1",
+			TCPPort:  9051,
+			QUICAddr: "127.0.0.1",
+			QUICPort: 9051,
+		},
+		Logging: &loggingConfig{
+			Level: flagLogLevel,
+		},
+	}
+	return src
+}
+
+func configFilePath() string {
+	path, err := homedir.Expand(flagConfigPath)
+	if err != nil {
+		log.Fatalf("could not parse config file path: %v", err)
+	}
+
+	if path != "" {
+		if _, err := os.Stat(path); err != nil {
+			// if someone passes an explicit config file path but it's
+			// mising, we shouldn't try another file unexpectedly
+			log.Fatalf("could not read config file: %v", err)
+		}
+		return path
+	}
+
+	// the other paths we try might not be there, so we handle that
+	// and try the next path
+	userDir, err := os.UserConfigDir()
+	if err == nil {
+		path = filepath.Join(userDir, "plan-vault", "vault.json")
+		_, err := os.Stat(path)
+		if err == nil {
+			return path
+		}
+		if !os.IsNotExist(err) {
+			log.Fatalf("could not read config file %q: %v", path, err)
+		}
+	}
+
+	path = filepath.Join(defaultEtcDir, "vault.json")
+	_, err = os.Stat(path)
+	if err == nil {
+		return path
+	}
+	if !os.IsNotExist(err) {
+		log.Fatalf("could not read config file %q: %v", path, err)
+	}
+	return ""
+}
+
+func (src *configSource) Print() {
+	pretty, err := json.MarshalIndent(src, "", "  ")
+	if err != nil {
+		log.Fatalf("could not pretty-print configuration")
+	}
+	fmt.Println(string(pretty))
+}
+
+// Config is just a wrapper around the constructed configs for each of
+// the internal services
+type Config struct {
+	ServerConfig *server.Config
+	StoreConfig  *store.Config
+	P2PConfig    *p2p.Config
+}
+
+func NewConfig() *Config {
+	src := newConfigSource()
+	cfg := &Config{
+		StoreConfig: &store.Config{
+			DataDir:      src.Store.DataDir,
+			HasDiscovery: src.P2P.URI != "",
+			Log:          log.WithFields(log.Fields{"service": "store"}),
+		},
+		ServerConfig: &server.Config{
+			Addr:        src.Server.BindAddr,
+			Port:        src.Server.Port,
+			TLSCertPath: src.Server.TLSCert,
+			TLSKeyPath:  src.Server.TLSKey,
+			Log:         log.WithFields(log.Fields{"service": "server"}),
+		},
+		P2PConfig: &p2p.Config{
+			MDNS:     src.P2P.MDNS,
+			URI:      src.P2P.URI,
+			TCPAddr:  src.P2P.TCPAddr,
+			TCPPort:  src.P2P.TCPPort,
+			QUICAddr: src.P2P.QUICAddr,
+			QUICPort: src.P2P.QUICPort,
+			KeyFile:  filepath.Join(src.KeyDir, "vault.key"),
+			Log:      log.WithFields(log.Fields{"service": "p2p"}),
+		},
+	}
+
+	cfg.StoreConfig.Init()
+	cfg.ServerConfig.Init()
+	cfg.P2PConfig.Init()
+	return cfg
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/plan-systems/plan-vault-libp2p
 go 1.15
 
 require (
+	github.com/apex/log v1.9.0
 	github.com/dgraph-io/badger/v2 v2.2007.2
 	github.com/golang/protobuf v1.4.3
 	github.com/libp2p/go-libp2p v0.12.0
@@ -11,6 +12,7 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.4.0
 	github.com/libp2p/go-libp2p-quic-transport v0.9.2
 	github.com/libp2p/go-libp2p-tls v0.1.3
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,14 @@ github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
+github.com/apex/log v1.9.0 h1:FHtw/xuaM8AgmvDDTI9fiwoAL25Sq2cxojnZICUU8l0=
+github.com/apex/log v1.9.0/go.mod h1:m82fZlWIuiWzWP04XCTXmnX0xRkYYbCdYn8jbJeLBEA=
+github.com/apex/logs v1.0.0/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
+github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
+github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/benbjohnson/clock v1.0.2 h1:Z0CN0Yb4ig9sGPXkvAQcGJfnrrMQ5QYLCMPRi9iD7YE=
+github.com/aws/aws-sdk-go v1.20.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/benbjohnson/clock v1.0.2/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.0.3 h1:vkLuvpK4fmtSCuo60+yC63p7y0BmQ8gm5ZXGuBCJyXg=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
@@ -78,6 +84,7 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6 h1:u/UEqS66A5ckRmS4yNpjmVH56sVtS/RfclBAYocb4as=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=
@@ -90,6 +97,7 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -211,6 +219,8 @@ github.com/jbenet/goprocess v0.1.4/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZl
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -222,6 +232,7 @@ github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/koron/go-ssdp v0.0.0-20191105050749-2e1c40ed0b5d h1:68u9r4wEvL3gYg2jvAOgROwZ3H+Y3hIDk4tbbmIjcYQ=
 github.com/koron/go-ssdp v0.0.0-20191105050749-2e1c40ed0b5d/go.mod h1:5Ky9EC2xfoUKUor0Hjgi2BJhCSXJfMOFlmyYrVKGQMk=
+github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -324,7 +335,6 @@ github.com/libp2p/go-libp2p-secio v0.2.2/go.mod h1:wP3bS+m5AUnFA+OFO7Er03uO1mncH
 github.com/libp2p/go-libp2p-swarm v0.1.0/go.mod h1:wQVsCdjsuZoc730CgOvh5ox6K8evllckjebkdiY5ta4=
 github.com/libp2p/go-libp2p-swarm v0.2.2/go.mod h1:fvmtQ0T1nErXym1/aa1uJEyN7JzaTNyBcHImCxRpPKU=
 github.com/libp2p/go-libp2p-swarm v0.2.3/go.mod h1:P2VO/EpxRyDxtChXz/VPVXyTnszHvokHKRhfkEgFKNM=
-github.com/libp2p/go-libp2p-swarm v0.2.8 h1:cIUUvytBzNQmGSjnXFlI6UpoBGsaud82mJPIJVfkDlg=
 github.com/libp2p/go-libp2p-swarm v0.2.8/go.mod h1:JQKMGSth4SMqonruY0a8yjlPVIkb0mdNSwckW7OYziM=
 github.com/libp2p/go-libp2p-swarm v0.3.0/go.mod h1:hdv95GWCTmzkgeJpP+GK/9D9puJegb7H57B5hWQR5Kk=
 github.com/libp2p/go-libp2p-swarm v0.3.1 h1:UTobu+oQHGdXTOGpZ4RefuVqYoJXcT0EBtSR74m2LkI=
@@ -333,7 +343,6 @@ github.com/libp2p/go-libp2p-testing v0.0.2/go.mod h1:gvchhf3FQOtBdr+eFUABet5a4MB
 github.com/libp2p/go-libp2p-testing v0.0.3/go.mod h1:gvchhf3FQOtBdr+eFUABet5a4MBLK8jM3V4Zghvmi+E=
 github.com/libp2p/go-libp2p-testing v0.0.4/go.mod h1:gvchhf3FQOtBdr+eFUABet5a4MBLK8jM3V4Zghvmi+E=
 github.com/libp2p/go-libp2p-testing v0.1.0/go.mod h1:xaZWMJrPUM5GlDBxCeGUi7kI4eqnjVyavGroI2nxEM0=
-github.com/libp2p/go-libp2p-testing v0.1.1 h1:U03z3HnGI7Ni8Xx6ONVZvUFOAzWYmolWf5W5jAOPNmU=
 github.com/libp2p/go-libp2p-testing v0.1.1/go.mod h1:xaZWMJrPUM5GlDBxCeGUi7kI4eqnjVyavGroI2nxEM0=
 github.com/libp2p/go-libp2p-testing v0.1.2-0.20200422005655-8775583591d8/go.mod h1:Qy8sAncLKpwXtS2dSnDOP8ktexIAHKu+J+pnZOFZLTc=
 github.com/libp2p/go-libp2p-testing v0.3.0 h1:ZiBYstPamsi7y6NJZebRudUzsYmVkt998hltyLqf8+g=
@@ -348,7 +357,6 @@ github.com/libp2p/go-libp2p-yamux v0.2.0/go.mod h1:Db2gU+XfLpm6E4rG5uGCFX6uXA8ME
 github.com/libp2p/go-libp2p-yamux v0.2.2/go.mod h1:lIohaR0pT6mOt0AZ0L2dFze9hds9Req3OfS+B+dv4qw=
 github.com/libp2p/go-libp2p-yamux v0.2.5/go.mod h1:Zpgj6arbyQrmZ3wxSZxfBmbdnWtbZ48OpsfmQVTErwA=
 github.com/libp2p/go-libp2p-yamux v0.2.7/go.mod h1:X28ENrBMU/nm4I3Nx4sZ4dgjZ6VhLEn0XhIoZ5viCwU=
-github.com/libp2p/go-libp2p-yamux v0.2.8 h1:0s3ELSLu2O7hWKfX1YjzudBKCP0kZ+m9e2+0veXzkn4=
 github.com/libp2p/go-libp2p-yamux v0.2.8/go.mod h1:/t6tDqeuZf0INZMTgd0WxIRbtK2EzI2h7HbFm9eAKI4=
 github.com/libp2p/go-libp2p-yamux v0.4.0 h1:qunEZzWwwmfSBYTtSyd81PlD1TjB5uuWcGYHWVXLbUg=
 github.com/libp2p/go-libp2p-yamux v0.4.0/go.mod h1:+DWDjtFMzoAwYLVkNZftoucn7PelNoy5nm3tZ3/Zw30=
@@ -358,7 +366,6 @@ github.com/libp2p/go-maddr-filter v0.1.0/go.mod h1:VzZhTXkMucEGGEOSKddrwGiOv0tUh
 github.com/libp2p/go-mplex v0.0.3/go.mod h1:pK5yMLmOoBR1pNCqDlA2GQrdAVTMkqFalaTWe7l4Yd0=
 github.com/libp2p/go-mplex v0.1.0/go.mod h1:SXgmdki2kwCUlCCbfGLEgHjC4pFqhTp0ZoV6aiKgxDU=
 github.com/libp2p/go-mplex v0.1.1/go.mod h1:Xgz2RDCi3co0LeZfgjm4OgUF15+sVR8SRcu3SFXI1lk=
-github.com/libp2p/go-mplex v0.1.2 h1:qOg1s+WdGLlpkrczDqmhYzyk3vCfsQ8+RxRTQjOZWwI=
 github.com/libp2p/go-mplex v0.1.2/go.mod h1:Xgz2RDCi3co0LeZfgjm4OgUF15+sVR8SRcu3SFXI1lk=
 github.com/libp2p/go-mplex v0.2.0 h1:Ov/D+8oBlbRkjBs1R1Iua8hJ8cUfbdiW8EOdZuxcgaI=
 github.com/libp2p/go-mplex v0.2.0/go.mod h1:0Oy/A9PQlwBytDRp4wSkFnzHYDKcpLot35JQ6msjvYQ=
@@ -404,7 +411,6 @@ github.com/libp2p/go-yamux v1.2.2/go.mod h1:FGTiPvoV/3DVdgWpX+tM0OW3tsM+W5bSE3gZ
 github.com/libp2p/go-yamux v1.3.0/go.mod h1:FGTiPvoV/3DVdgWpX+tM0OW3tsM+W5bSE3gZwqQTcow=
 github.com/libp2p/go-yamux v1.3.3/go.mod h1:FGTiPvoV/3DVdgWpX+tM0OW3tsM+W5bSE3gZwqQTcow=
 github.com/libp2p/go-yamux v1.3.5/go.mod h1:FGTiPvoV/3DVdgWpX+tM0OW3tsM+W5bSE3gZwqQTcow=
-github.com/libp2p/go-yamux v1.3.7 h1:v40A1eSPJDIZwz2AvrV3cxpTZEGDP11QJbukmEhYyQI=
 github.com/libp2p/go-yamux v1.3.7/go.mod h1:fr7aVgmdNGJK+N1g+b6DW6VxzbRCjCOejR/hkmpooHE=
 github.com/libp2p/go-yamux v1.4.0 h1:7nqe0T95T2CWh40IdJ/tp8RMor4ubc9/wYZpB2a/Hx0=
 github.com/libp2p/go-yamux v1.4.0/go.mod h1:fr7aVgmdNGJK+N1g+b6DW6VxzbRCjCOejR/hkmpooHE=
@@ -421,8 +427,10 @@ github.com/marten-seemann/qtls-go1-15 v0.1.1 h1:LIH6K34bPVttyXnUWixk0bzH6/N07Vxb
 github.com/marten-seemann/qtls-go1-15 v0.1.1/go.mod h1:GyFwywLKkRt+6mfU99csTEY1joMZz5vmB1WNZH3P81I=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
@@ -438,6 +446,7 @@ github.com/minio/sha256-simd v0.1.0/go.mod h1:2FMWW+8GMoPweT6+pI63m9YE3Lmw4J71hV
 github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
 github.com/minio/sha256-simd v0.1.1 h1:5QHSlgo3nt5yKOJrC7W8w7X+NFl8cMPZm96iu8kKUJU=
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -531,6 +540,7 @@ github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
@@ -557,6 +567,9 @@ github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95/go.
 github.com/shurcooL/users v0.0.0-20180125191416-49c67e49c537/go.mod h1:QJTqeLYEDaXHZDBsXlPCDqdhQuJkuw4NOtaxYe3xii4=
 github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133/go.mod h1:hKmq5kWdCj2z2KEozexVbfEZIWiTjhE0+UjmZgPqehw=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/smartystreets/assertions v1.0.0/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
+github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h1:SnhjPscd9TpLiy1LpzGSKh3bXCfxxXuqd9xmQJy3slM=
+github.com/smartystreets/gunit v1.0.0/go.mod h1:qwPWnhz6pn0NnRBP++URONOVyNkPyr4SauJk4cUOwJs=
 github.com/smola/gocompat v0.2.0/go.mod h1:1B0MlxbmoZNo3h8guHp8HztB3BSYR5itql9qtVc0ypY=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
@@ -574,7 +587,6 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/src-d/envconfig v1.0.0/go.mod h1:Q9YQZ7BKITldTBnoxsE5gOeB5y66RyPXeue/R4aaNBc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -584,6 +596,13 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
+github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
+github.com/tj/assert v0.0.3 h1:Df/BlaZ20mq6kuai7f5z2TvPFiwC3xaWJSDQNiIS3Rk=
+github.com/tj/assert v0.0.3/go.mod h1:Ne6X72Q+TB1AteidzQncjw9PabbMp4PBMZ1k+vd1Pvk=
+github.com/tj/go-buffer v1.1.0/go.mod h1:iyiJpfFcR2B9sXu7KvjbT9fpM4mOelRSDTbntVj52Uc=
+github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eNAjXGDx2yma7uG2XoyRZTq1uv3M/o7imD0=
+github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPfx6jb1bBgRFjl5lytqVqZXEaeqWP8lTEao=
+github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
@@ -637,9 +656,7 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190618222545-ea8f1a30c443/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5 h1:Q7tZBpemrlsc2I7IyODzhtallWRSm4Q0d09pL6XbQtU=
 golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rBCcS0QyQY66Mpf/7BZbInM=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -665,7 +682,6 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190313220215-9f648a60d977/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20190923162816-aa69164e4478 h1:l5EDrHhldLYb3ZRHDUhXF7Om7MvYXnkV9/iQNo1lX6g=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
@@ -703,7 +719,6 @@ golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7NkNAQs+6Q8b9WEB/F4=
@@ -791,8 +806,9 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c h1:grhR+C34yXImVGp7EzNk+DTIk+323eIUWOmEevy6bDo=
+gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/keyring/file.go
+++ b/keyring/file.go
@@ -69,11 +69,7 @@ func getKeys(path string) (crypto.PrivKey, crypto.PubKey, error) {
 }
 
 func loadKey(path string) (crypto.PrivKey, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	b, err := ioutil.ReadAll(file)
+	b, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -2,28 +2,25 @@ package main
 
 import (
 	"context"
-	"flag"
 	"log"
 
+	"github.com/plan-systems/plan-vault-libp2p/config"
 	"github.com/plan-systems/plan-vault-libp2p/p2p"
 	"github.com/plan-systems/plan-vault-libp2p/server"
 	"github.com/plan-systems/plan-vault-libp2p/store"
 )
 
 func main() {
-	flag.Parse()
+	cfg := config.NewConfig()
 	ctx := context.Background()
-
-	cfg := store.DefaultConfig()
-	db, err := store.New(ctx, cfg)
+	db, err := store.New(ctx, cfg.StoreConfig)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	p2pCfg := p2p.DefaultConfig()
-	_, err = p2p.New(ctx, db, p2pCfg)
+	_, err = p2p.New(ctx, db, cfg.P2PConfig)
 	if err != nil {
 		log.Fatal(err)
 	}
-	server.Run(ctx, db)
+	server.Run(ctx, db, cfg.ServerConfig)
 }

--- a/p2p/config.go
+++ b/p2p/config.go
@@ -1,27 +1,33 @@
 package p2p
 
-import "flag"
-
-// TODO: improve the configuration story here
-var (
-	port    = flag.Int("p2p_port", 9000, "p2p server port port")
-	keyFile = flag.String("key_file", "/tmp/vault.key", "path to key file")
+import (
+	"github.com/apex/log"
 )
 
 type Config struct {
-	NoP2P               bool
-	NoMDNS              bool
-	DiscoveryChannelURI string
-	Port                int
-	KeyFile             string
+	MDNS     bool
+	URI      string
+	TCPAddr  string
+	TCPPort  int
+	QUICAddr string
+	QUICPort int
+	KeyFile  string
+	Log      *log.Entry
 }
 
-func DefaultConfig() Config {
+// Init overrides the configuration values of the Config object with
+// those passed in as flags
+func (cfg *Config) Init() {}
+
+func DevConfig() Config {
 	return Config{
-		NoP2P:               false,
-		NoMDNS:              false,
-		DiscoveryChannelURI: "/TODO",
-		Port:                *port,
-		KeyFile:             *keyFile,
+		MDNS:     true,
+		URI:      "/DISCOVERY",
+		TCPAddr:  "127.0.0.1",
+		TCPPort:  9051,
+		QUICAddr: "127.0.0.1",
+		QUICPort: 9051,
+		KeyFile:  "/tmp/vault.key",
+		Log:      log.WithFields(log.Fields{"service": "p2p"}),
 	}
 }

--- a/p2p/discovery_channel.go
+++ b/p2p/discovery_channel.go
@@ -14,7 +14,7 @@ import (
 )
 
 func NewChannelDiscovery(pctx context.Context, h *Host, cfg *Config) (*TopicHandler, error) {
-	channelID := helpers.ChannelURItoChannelID(cfg.DiscoveryChannelURI)
+	channelID := helpers.ChannelURItoChannelID(cfg.URI)
 	channel, err := h.store.Channel(channelID)
 	if err != nil {
 		return nil, err

--- a/server/config.go
+++ b/server/config.go
@@ -1,18 +1,33 @@
 package server
 
 import (
-	"flag"
+	"path/filepath"
 
+	"github.com/apex/log"
 	pb "github.com/plan-systems/plan-vault-libp2p/protos"
 )
 
 var defaultPort = int(pb.Const_DefaultGrpcServicePort)
 
-// TODO: improve the configuration story here
-var (
-	tls         = flag.Bool("tls", false, "Connection uses TLS if true, else plain TCP")
-	certFile    = flag.String("cert_file", "x509/server_cert.pem", "The TLS cert file")
-	certKeyFile = flag.String("cert_key_file", "x509/server_key.pem", "The TLS key file")
-	grpcAddr    = flag.String("addr", "127.0.0.1", "gRPC server address")
-	grpcPort    = flag.Int("port", defaultPort, "gRPC server port port")
-)
+type Config struct {
+	Addr        string
+	Port        int
+	TLSCertPath string
+	TLSKeyPath  string
+	Log         *log.Entry
+}
+
+// Init overrides the configuration values of the Config object with
+// those passed in as flags
+func (cfg *Config) Init() {}
+
+func DevConfig() *Config {
+	baseDir := "/tmp"
+	return &Config{
+		Addr:        "127.0.0.1",
+		Port:        defaultPort,
+		TLSCertPath: filepath.Join(baseDir, "vault_cert.pem"),
+		TLSKeyPath:  filepath.Join(baseDir, "vault_key.pem"),
+		Log:         log.WithFields(log.Fields{"service": "grpc"}),
+	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -23,7 +23,7 @@ func TestServer_NewOpenClose(t *testing.T) {
 	defer cancel()
 	db := dbSetup(t, ctx)
 
-	server := &VaultServer{ctx: ctx, db: db}
+	server := &VaultServer{ctx: ctx, db: db, log: DevConfig().Log}
 
 	session := newMockSessionServer(ctx)
 	go server.VaultSession(session)
@@ -122,7 +122,7 @@ func TestServer_StreamAppend(t *testing.T) {
 	defer cancel()
 	db := dbSetup(t, ctx)
 
-	server := &VaultServer{ctx: ctx, db: db}
+	server := &VaultServer{ctx: ctx, db: db, log: DevConfig().Log}
 
 	session := newMockSessionServer(ctx)
 	go server.VaultSession(session)
@@ -157,7 +157,7 @@ func TestServer_InvalidRequests(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	server := &VaultServer{ctx: ctx}
+	server := &VaultServer{ctx: ctx, log: DevConfig().Log}
 	session := newMockSessionServer(ctx)
 	go server.VaultSession(session)
 
@@ -374,8 +374,8 @@ func dbSetup(t *testing.T, ctx context.Context) *store.Store {
 	return store
 }
 
-func testConfig() store.Config {
-	cfg := store.DefaultConfig()
+func testConfig() *store.Config {
+	cfg := store.DevConfig()
 	cfg.DB = cfg.DB.
 		WithDir("").                     // need to unset for in-memory
 		WithValueDir("").                // need to unset for in-memory

--- a/store/config.go
+++ b/store/config.go
@@ -1,24 +1,56 @@
 package store
 
 import (
-	"flag"
-
+	"github.com/apex/log"
 	"github.com/dgraph-io/badger/v2"
 )
 
-// TODO: improve the configuration story here
-var (
-	dataDir = flag.String("data_dir", "/tmp/badger", "directory for database storage")
-)
-
 type Config struct {
+	DataDir      string
 	DB           badger.Options
-	HasDiscovery bool // TODO: replace this with top-level config
+	HasDiscovery bool
+	Log          *log.Entry
 }
 
-func DefaultConfig() Config {
-	return Config{
-		DB:           badger.DefaultOptions(*dataDir),
+// Init overrides the configuration values of the Config object with
+// those passed in as flags
+func (cfg *Config) Init() {
+	cfg.DB = badger.DefaultOptions(cfg.DataDir).
+		WithLogger(BadgerLogger{logger: cfg.Log})
+}
+
+func DevConfig() *Config {
+	dataDir := "/tmp/db"
+	logger := log.WithFields(log.Fields{"service": "store"})
+	return &Config{
+		DataDir: dataDir,
+		DB: badger.DefaultOptions(dataDir).
+			WithLogger(BadgerLogger{logger: logger}),
 		HasDiscovery: false,
+		Log:          logger,
 	}
+}
+
+// BadgerLogger wraps the apex logger. The badger.Logger says it's
+// "implemented by any logging system that is used for standard logs"
+// but it turns out only klog implements their logs with this interface
+// and klog is still missing structured fields
+type BadgerLogger struct {
+	logger *log.Entry
+}
+
+func (l BadgerLogger) Errorf(msg string, objs ...interface{}) {
+	l.logger.Errorf(msg, objs...)
+}
+
+func (l BadgerLogger) Warningf(msg string, objs ...interface{}) {
+	l.logger.Warnf(msg, objs...)
+}
+
+func (l BadgerLogger) Infof(msg string, objs ...interface{}) {
+	l.logger.Infof(msg, objs...)
+}
+
+func (l BadgerLogger) Debugf(msg string, objs ...interface{}) {
+	l.logger.Debugf(msg, objs...)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -86,7 +86,7 @@ type ChannelID = [32]byte
 type StoreKey = []byte
 type ArrivalKey = []byte
 
-func New(ctx context.Context, cfg Config) (*Store, error) {
+func New(ctx context.Context, cfg *Config) (*Store, error) {
 
 	db, err := badger.Open(cfg.DB)
 	if err != nil {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -415,8 +415,9 @@ func setup(t *testing.T) (*Channel, context.Context, func()) {
 	return channel, ctx, cancel
 }
 
-func testConfig() Config {
-	cfg := DefaultConfig()
+func testConfig() *Config {
+	cfg := DevConfig()
+	cfg.HasDiscovery = false
 	cfg.DB = cfg.DB.
 		WithDir("").                     // need to unset for in-memory
 		WithValueDir("").                // need to unset for in-memory


### PR DESCRIPTION
Move most of the command line flags into a configuration file (JSON,
for now at least), which gets parsed at startup if available. Move all
the command line / parsing logic into its own package that sets up the
`Config` object for each internal service.

Use apex/log as the base logger so that we can have structured logs
with fields and nicer formatting than klog, but this commit doesn't
configure the formatting.

Includes a `-print` flag that will dump a default config file to
stdout if no file is available.